### PR TITLE
modbus-client.js: fix validation of serialPort in dynamic reconnect

### DIFF
--- a/src/modbus-client.js
+++ b/src/modbus-client.js
@@ -766,7 +766,7 @@ module.exports = function (RED) {
           break
         case 'SERIAL':
           if (msg.payload.serialPort) {
-            node.serialPort = parseInt(msg.payload.serialPort) || node.serialPort
+            node.serialPort = msg.payload.serialPort || node.serialPort
           }
 
           if (msg.payload.serialBaudrate) {


### PR DESCRIPTION
Signed-off-by: Edoardo Scaglia <edoardo.87@gmail.com>